### PR TITLE
Handle folder with quotes

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.downloadfiles
 
+import java.io.File
 import java.util.UUID
 
 import com.amazonaws.services.lambda.runtime.Context
@@ -54,11 +55,8 @@ class Lambda {
           val consignmentId = UUID.fromString(s3KeyArr.init.tail(0))
           fileUtils.getFilePath(keycloakUtils, client, fileId).flatMap(originalPath => {
             val prefix = s"$efsRootLocation/$consignmentId"
-            val writeDirectory = originalPath.split("/").init.mkString("/") match {
-              case doubleQuotes if doubleQuotes.contains("\"") => s"""'$prefix/$doubleQuotes'"""
-              case noDoubleQuotes => s""""$prefix/$noDoubleQuotes""""
-            }
-            s"""mkdir -p $writeDirectory """.!!
+            val writeDirectory = originalPath.split("/").init.mkString("/")
+            new File(s"$prefix/$writeDirectory").mkdirs()
             val writePath = s"$efsRootLocation/$consignmentId/$originalPath"
             val s3Response = fileUtils.writeFileFromS3(writePath, fileId, record, s3).map(_ => {
               fileFormatSendMessage(DownloadOutput(cognitoId, consignmentId, fileId, originalPath).asJson.noSpaces)

--- a/src/test/resources/json/original_path_with_quotes_response.json
+++ b/src/test/resources/json/original_path_with_quotes_response.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "getClientFileMetadata": {
+      "originalPath": "a\"pathwith/quotes\"in"
+    }
+  }
+}

--- a/src/test/resources/json/original_path_with_quotes_response.json
+++ b/src/test/resources/json/original_path_with_quotes_response.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "getClientFileMetadata": {
-      "originalPath": "a\"pathwith/quotes\"in"
+      "originalPath": "a\"path'with/quo'tes\"in"
     }
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/downloadfiles/ExternalServicesTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/downloadfiles/ExternalServicesTest.scala
@@ -35,6 +35,9 @@ class ExternalServicesTest extends AnyFlatSpec with BeforeAndAfterEach with Befo
   def graphqlOriginalPathWithSpace: StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
     .willReturn(okJson(fromResource(s"json/original_path_with_space_response.json").mkString)))
 
+  def graphqlOriginalPathWithQuotes: StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
+    .willReturn(okJson(fromResource(s"json/original_path_with_quotes_response.json").mkString)))
+
   def authOk: StubMapping = wiremockAuthServer.stubFor(post(urlEqualTo(authPath))
     .willReturn(okJson(fromResource(s"json/access_token.json").mkString)))
 

--- a/src/test/scala/uk/gov/nationalarchives/downloadfiles/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/downloadfiles/LambdaTest.scala
@@ -119,7 +119,7 @@ class LambdaTest extends ExternalServicesTest {
     graphqlOriginalPathWithQuotes
     putFile("testfile")
     new Lambda().process(createEvent("sns_s3_event"), null)
-    val fileAttempt = Try(Source.fromFile("./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/a\"pathwith/quotes\"in"))
+    val fileAttempt = Try(Source.fromFile("./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/a\"path'with/quo'tes\"in"))
     fileAttempt.isSuccess should be(true)
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/downloadfiles/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/downloadfiles/LambdaTest.scala
@@ -114,6 +114,15 @@ class LambdaTest extends ExternalServicesTest {
     fileAttempt.isSuccess should be(true)
   }
 
+  "The process method" should "write the file to the correct path if the original path contains quotes" in {
+    wiremockGraphqlServer.resetAll()
+    graphqlOriginalPathWithQuotes
+    putFile("testfile")
+    new Lambda().process(createEvent("sns_s3_event"), null)
+    val fileAttempt = Try(Source.fromFile("./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/a\"pathwith/quotes\"in"))
+    fileAttempt.isSuccess should be(true)
+  }
+
   private def checkOutput(output: DownloadOutput): Unit = {
     output.consignmentId should equal(UUID.fromString("f0a73877-6057-4bbb-a1eb-7c7b73cab586"))
     output.fileId should equal(UUID.fromString("acea5919-25a3-4c6b-8908-fa47cc77878f"))


### PR DESCRIPTION
Use single quotes if the path contains double quotes    
    
If there is a quote in the folder name, the mkdir step fails as it's contained in double quotes. What I was thinking is that for all special characters apart from double quotes, we can enclose the folder path with double quotes.
For double quotes, we enclose the path in single quotes.

