### PR TITLE
Format logs as JSON

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val root = (project in file("."))
         graphqlClient,
         scalaLogging,
         logback,
+        logstashLogbackEncoder,
         scalaTest % Test,
         mockito % Test,
         s3Mock % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
+  lazy val logstashLogbackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"
   lazy val s3Mock = "io.findify" %% "s3mock" % "0.2.6"
   lazy val sqsMock = "io.findify" %% "sqsmock" % "0.3.4"

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="json" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"application":"tdr-download-files"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="json" />
+    </root>
+</configuration>


### PR DESCRIPTION
This makes it easier to search logs because CloudWatch Insights can search by JSON field keys. It also solves the bug where CloudWatch splits each line of a stack trace into its own log event.

The long-term goal is to convert all logging to JSON: https://national-archives.atlassian.net/browse/TDR-894

Also log file ID and consignment ID as structured JSON fields. This will make it possible to search for them as fields in CloudWatch Insights.