### PR TITLE
Fix NullPointerException when message body has wrong format

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
@@ -93,7 +93,7 @@ class Lambda {
     )
 
     val (downloadFileFailed: List[Throwable], downloadFileSucceeded) = results.partitionMap(_.toEither)
-    val allErrors: List[Throwable] = downloadFileFailed ++ eventsWithErrors.errors.map(_.getCause)
+    val allErrors: List[Throwable] = downloadFileFailed ++ eventsWithErrors.errors
     if (allErrors.nonEmpty) {
       allErrors.foreach(e => logger.error(e.getMessage, e))
       downloadFileSucceeded.map(deleteMessage)

--- a/src/test/resources/json/sns_empty_message.json
+++ b/src/test/resources/json/sns_empty_message.json
@@ -1,0 +1,12 @@
+{
+  "Type": "Notification",
+  "MessageId": "",
+  "TopicArn": "",
+  "Subject": "",
+  "Message": "{}",
+  "Timestamp": "2020-06-04T03:10:00.000Z",
+  "SignatureVersion": "1",
+  "Signature": "",
+  "SigningCertURL": "",
+  "UnsubscribeURL": ""
+}


### PR DESCRIPTION
If the message body could not be parsed as an S3 event, Circe would throw an exception. This exception has no nested cause, so the call to `getCause` in the error handling was causing a NullPointerException.

This meant that the Lambda would fail before the successful messages were deleted from the queue, causing them all to be retried. It also hides the original cause of the error.

This is not a big problem at the moment because the batch size is 1, but it would be a problem if we ever did start processing multiple messages.