### PR TITLE
Add entry point for running the Lambda script locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 ## Download Files From S3
 
-This is a lambda which takes the messages from the S3 uploads and downloads them to the EFS volume, where they can be reused by other processes.
+This is a lambda which takes the messages from the S3 uploads and downloads them to the EFS volume. It then sends
+messages to each of the file check queues. Those messages trigger the file check Lambdas, which use the files downloaded
+to EFS by this Lambda.
+
+See the [architecture diagram] and [file check architecture decision record][adr] for more context about how this Lambda
+fits into the file check workflow.
+
+[architecture diagram]: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/beta-architecture/beta-architecture.md
+[adr]: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/architecture-decision-records/0013-file-check-queues-and-lambdas.md
 
 ### Adding new environment variables to the tests
 The environment variables in the deployed lambda are encrypted using KMS and then base64 encoded. These are then decoded in the lambda. Because of this, any variables in `src/test/resources/application.conf` which come from environment variables in `src/main/resources/application.conf` need to be stored base64 encoded. There are comments next to each variable to say what the base64 string decodes to. If you want to add a new variable you can run `echo -n "value of variable" | base64 -w 0` and paste the output into the test application.conf

--- a/README.md
+++ b/README.md
@@ -1,7 +1,38 @@
 ## Download Files From S3
 
-This will be a lambda which will take the messages from the S3 uploads and download them to the EFS volume, where they can be reused by other processes.
+This is a lambda which takes the messages from the S3 uploads and downloads them to the EFS volume, where they can be reused by other processes.
 
 ### Adding new environment variables to the tests
 The environment variables in the deployed lambda are encrypted using KMS and then base64 encoded. These are then decoded in the lambda. Because of this, any variables in `src/test/resources/application.conf` which come from environment variables in `src/main/resources/application.conf` need to be stored base64 encoded. There are comments next to each variable to say what the base64 string decodes to. If you want to add a new variable you can run `echo -n "value of variable" | base64 -w 0` and paste the output into the test application.conf
 
+### Local development
+
+Set the following environment variables, either on the command line or in an IntelliJ run configuration, depending on
+where you want to run the app. The suggested values assume that you want to run the Lambda against the integration
+environment.
+
+- `INPUT_QUEUE`: The URL of the download files SQS queue. You can get a list of all queue URLs by running
+  `aws sqs list-queues`
+- `ANTIVIRUS_QUEUE`: The URL of the antivirus SQS queue
+- `CHECKSUM_QUEUE`: The URL of the checksum SQS queue
+- `FILE_FORMAT_QUEUE`: The URL of the file format SQS queue
+- `AWS_LAMBDA_FUNCTION_NAME`: The name of the download files Lambda, which on intg is `tdr-download-files-intg`
+- `ROOT_DIRECTORY`: A directory on your own machine that the S3 files will be downloaded to, e.g.
+  `/tmp/test-download-files`.
+- `CLIENT_ID`: The Keycloak client ID of the file checks client, which is `tdr-backend-checks`
+- `CLIENT_SECRET`: The secret key for the Keycloak client, which you can look up in Keycloak on intg or by running
+  `aws ssm get-parameter --name "/intg/keycloak/backend_checks_client/secret" --with-decryption`
+- `API_URL`: The URL of the GraphQL API endpoint, which on intg is
+  `https://api.tdr-integration.nationalarchives.gov.uk/graphql`
+
+Log into AWS SSO, and copy credentials for intg to your AWS credentials file.
+
+On the command line, run `sbt run`. In IntelliJ, run the `LambdaRunner` app.
+
+The `LambdaRunner` hard-codes a message for a specific file ID. This corresponds to a small text file that was uploaded
+to intg. You can use a different file ID, but you'll need to set the consignment ID and Cognito user ID to the correct
+values for the file so that they match the object ID in S3.
+
+Running the `LambdaRunner` will add messages to the downstream file check queues, so the real file checks will start on
+the AWS environment. If you want to avoid this, set the three file check queue environment variables to the URL of the
+failure queue instead.

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,8 +14,7 @@ sqs {
 
 efs {
     root {
-        # TODO: Either add a default or make this mandatory
-        location = ${?ROOT_DIRECTORY}
+        location = ${ROOT_DIRECTORY}
     }
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,6 +14,7 @@ sqs {
 
 efs {
     root {
+        # TODO: Either add a default or make this mandatory
         location = ${?ROOT_DIRECTORY}
     }
 }

--- a/src/main/scala/uk/gov/nationalarchives/downloadfiles/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/downloadfiles/LambdaRunner.scala
@@ -1,0 +1,96 @@
+package uk.gov.nationalarchives.downloadfiles
+
+import java.io.File
+import java.util.UUID
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import com.typesafe.config.ConfigFactory
+
+import scala.jdk.CollectionConverters._
+import scala.reflect.io.Directory
+
+// An entry point you can use to run the Lambda code locally
+object LambdaRunner extends App {
+  val fileId: UUID = UUID.fromString("686181e5-8379-4b39-8681-7e71aab2e98d")
+  val consignmentId: UUID = UUID.fromString("750aa09a-1254-4e2f-b9b9-c838ed091dd6")
+  val cognitoUserId: String = "eu-west-2:56f64881-67ca-4657-87dc-3065a6ce3b20"
+  val bucketName: String = "tdr-upload-files-dirty-intg"
+  val downloadPath = ConfigFactory.load.getString("efs.root.location")
+
+  wipeConsignmentDirectory(downloadPath, consignmentId)
+
+  val fakeSqsEvent = buildSqsEvent(fileId, consignmentId, cognitoUserId, bucketName)
+
+  // Context is not used, so it's safe to pass null
+  val emptyLambdaContext = null
+
+
+  new Lambda().process(fakeSqsEvent, emptyLambdaContext)
+
+  private def wipeConsignmentDirectory(downloadRootPath: String, consignmentId: UUID): Unit = {
+    val consignmentDirectory = new Directory(new File(s"$downloadRootPath/$consignmentId"))
+    consignmentDirectory.deleteRecursively()
+  }
+
+  private def buildSqsEvent(fileId: UUID, consignmentId: UUID, cognitoUserId: String, bucketName: String) = {
+    val body: String = buildMessageBody(fileId, consignmentId, cognitoUserId, bucketName)
+    val snsMessage: String = buildSnsMessage(body)
+
+    val sqsMessage = new SQSMessage
+    sqsMessage.setBody(snsMessage)
+
+    val fakeSqsEvent = new SQSEvent
+    fakeSqsEvent.setRecords(List(sqsMessage).asJava)
+
+    fakeSqsEvent
+  }
+
+  private def buildMessageBody(fileId: UUID, consignmentId: UUID, cognitoUserId: String, bucketName: String): String = {
+    val s3ObjectKey = s"$cognitoUserId/$consignmentId/$fileId"
+
+    s"""{
+      |   "Records": [
+      |       {
+      |           "eventVersion": "",
+      |           "eventSource": "",
+      |           "awsRegion": "eu-west-2",
+      |           "eventTime": "2020-06-04T03:10:00.000Z",
+      |           "eventName": "",
+      |           "userIdentity": {"principalId": ""},
+      |           "requestParameters": {"sourceIPAddress": ""},
+      |           "responseElements": {"x-amz-request-id":"","x-amz-id-2":""},
+      |           "s3": {
+      |               "s3SchemaVersion": "",
+      |               "configurationId": "",
+      |               "bucket": {"name": "$bucketName","ownerIdentity": {"principalId":""},"arn": ""},
+      |               "object": {
+      |                   "key": "$s3ObjectKey",
+      |                   "size":10,
+      |                   "eTag":"",
+      |                   "versionId":"",
+      |                   "sequencer":""
+      |               }
+      |           }
+      |       }
+      |   ]
+      |}""".stripMargin
+  }
+
+  private def buildSnsMessage(body: String): String = {
+    val escapedMessageBody = body.replace(""""""", """\"""").replace("\n", "")
+
+    s"""{
+       |    "Type": "Notification",
+       |    "MessageId": "",
+       |    "TopicArn": "",
+       |    "Subject": "",
+       |    "Message": "$escapedMessageBody",
+       |    "Timestamp" : "2020-06-04T03:10:00.000Z",
+       |    "SignatureVersion": "1",
+       |    "Signature": "",
+       |    "SigningCertURL" : "",
+       |    "UnsubscribeURL" : ""
+       |}""".stripMargin
+  }
+}


### PR DESCRIPTION
Add a Scala App object which calls the Lambda, so that you can run the code locally. If you set the environment variables to
point to the queues on the integration environment, it will download the file from intg S3 and send messages to the intg SQS queues.

It saves the S3 file to a local folder instead of EFS, because EFS volumes are mounted on Lambda as if they were local folders anyway.

The code for generating an SNS message is quite verbose because there's no easy way to serialize an SNS object to JSON. The AWS SDK v1 has a class called `SnsMessageManager` which might help, but it's not available in the SDK v2.