### PR TITLE
Replace sqsMock with elasticMqSqs in tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,23 @@ fits into the file check workflow.
 [adr]: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/architecture-decision-records/0013-file-check-queues-and-lambdas.md
 
 ### Adding new environment variables to the tests
-The environment variables in the deployed lambda are encrypted using KMS and then base64 encoded. These are then decoded in the lambda. Because of this, any variables in `src/test/resources/application.conf` which come from environment variables in `src/main/resources/application.conf` need to be stored base64 encoded. There are comments next to each variable to say what the base64 string decodes to. If you want to add a new variable you can run `echo -n "value of variable" | base64 -w 0` and paste the output into the test application.conf
+The environment variables in the deployed lambda are encrypted using KMS and then base64 encoded. These are then decoded
+in the lambda. Because of this, any variables in `src/test/resources/application.conf` which come from environment
+variables in `src/main/resources/application.conf` need to be stored base64 encoded. There are comments next to each
+variable to say what the base64 string decodes to. If you want to add a new variable you can run `base64` and paste the
+output into the test application.conf.
+
+On Linux, run:
+
+```
+`echo -n "value of variable" | base64 -w 0`
+```
+
+On Mac, run:
+
+```
+`echo -n "value of variable" | base64`
+```
 
 ### Local development
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,8 @@ lazy val root = (project in file("."))
         scalaTest % Test,
         mockito % Test,
         s3Mock % Test,
-        sqsMock % Test
+        elasticMq % Test,
+        elasticMqSqs % Test
       )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,5 +16,6 @@ object Dependencies {
   lazy val logstashLogbackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
   lazy val mockito = "org.mockito" %% "mockito-scala" % "1.14.1"
   lazy val s3Mock = "io.findify" %% "s3mock" % "0.2.6"
-  lazy val sqsMock = "io.findify" %% "sqsmock" % "0.3.4"
+  lazy val elasticMq = "org.elasticmq" %% "elasticmq-server" % "1.1.1"
+  lazy val elasticMqSqs = "org.elasticmq" %% "elasticmq-rest-sqs" % "1.1.1"
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -5,10 +5,10 @@ s3 {
 sqs {
     endpoint = "http://localhost:8001"
     queue {
-        input = "aHR0cDovL2xvY2FsaG9zdDo4MDAxLzEvdGVzdHF1ZXVlaW5wdXQ=" # http://localhost:8001/1/testqueueinput
-        fileformat = "aHR0cDovL2xvY2FsaG9zdDo4MDAxLzEvdGVzdGZmcXVldWVvdXRwdXQ=" # http://localhost:8001/1/testffqueueoutput
-        antivirus = "aHR0cDovL2xvY2FsaG9zdDo4MDAxLzEvdGVzdGF2cXVldWVvdXRwdXQ=" # http://localhost:8001/1/testavqueueoutput
-        checksum = "aHR0cDovL2xvY2FsaG9zdDo4MDAxLzEvdGVzdGNoZWNrc3VtcXVldWVvdXRwdXQ=" # http://localhost:8001/1/testchecksumqueueoutput
+        input = "aHR0cDovL2xvY2FsaG9zdDo4MDAxL3F1ZXVlL3Rlc3RxdWV1ZWlucHV0" # http://localhost:8001/queue/testqueueinput
+        fileformat = "aHR0cDovL2xvY2FsaG9zdDo4MDAxL3F1ZXVlL3Rlc3RmZnF1ZXVlb3V0cHV0" # http://localhost:8001/queue/testffqueueoutput
+        antivirus = "aHR0cDovL2xvY2FsaG9zdDo4MDAxL3F1ZXVlL3Rlc3RhdnF1ZXVlb3V0cHV0" # http://localhost:8001/queue/testavqueueoutput
+        checksum = "aHR0cDovL2xvY2FsaG9zdDo4MDAxL3F1ZXVlL3Rlc3RjaGVja3N1bXF1ZXVlb3V0cHV0" # http://localhost:8001/queue/testchecksumqueueoutput
     }
 }
 

--- a/src/test/scala/uk/gov/nationalarchives/downloadfiles/ExternalServicesTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/downloadfiles/ExternalServicesTest.scala
@@ -1,5 +1,8 @@
 package uk.gov.nationalarchives.downloadfiles
 
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.{okJson, post, urlEqualTo}
@@ -16,8 +19,6 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import uk.gov.nationalarchives.downloadfiles.AWSUtils._
 
-import java.nio.ByteBuffer
-import java.nio.charset.Charset
 import scala.concurrent.ExecutionContext
 import scala.io.Source.fromResource
 import scala.sys.process._
@@ -72,11 +73,6 @@ class ExternalServicesTest extends AnyFlatSpec with BeforeAndAfterEach with Befo
     wiremockGraphqlServer.start()
     wiremockAuthServer.start()
     wiremockKmsEndpoint.start()
-    api.start()
-    inputQueueHelper.createQueue
-    avOutputQueueHelper.createQueue
-    ffOutputQueueHelper.createQueue
-    checksumOutputQueueHelper.createQueue
   }
 
   override def beforeEach(): Unit = {
@@ -84,13 +80,16 @@ class ExternalServicesTest extends AnyFlatSpec with BeforeAndAfterEach with Befo
     graphqlOriginalPath
     authOk
     createBucket
+    inputQueueHelper.createQueue
+    avOutputQueueHelper.createQueue
+    ffOutputQueueHelper.createQueue
+    checksumOutputQueueHelper.createQueue
   }
 
   override def afterAll(): Unit = {
     wiremockGraphqlServer.stop()
     wiremockAuthServer.stop()
     wiremockKmsEndpoint.stop()
-    api.shutdown()
   }
 
   override def afterEach(): Unit = {
@@ -99,5 +98,9 @@ class ExternalServicesTest extends AnyFlatSpec with BeforeAndAfterEach with Befo
     wiremockGraphqlServer.resetAll()
     wiremockKmsEndpoint.resetAll()
     "rm -rf ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586".!
+    inputQueueHelper.deleteQueue
+    avOutputQueueHelper.deleteQueue
+    ffOutputQueueHelper.deleteQueue
+    checksumOutputQueueHelper.deleteQueue
   }
 }


### PR DESCRIPTION
This will allow us to test changes to the message visibility, which aren't possible with sqsMock.

Also add Mac base64 command for encoding test config values.