### PR TITLE
Reset message visibility if an error happens when downloading the files

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val circeParser = "io.circe" %% "circe-parser" % "0.13.0"
   lazy val lambdaJavaCore = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val lambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.1.0"
-  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.15"
+  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.16"
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.19"
   lazy val generatedGraphql =  "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.60"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15"

--- a/src/main/scala/uk/gov/nationalarchives/downloadfiles/FailedDownloadException.scala
+++ b/src/main/scala/uk/gov/nationalarchives/downloadfiles/FailedDownloadException.scala
@@ -1,0 +1,4 @@
+package uk.gov.nationalarchives.downloadfiles
+
+case class FailedDownloadException(sqsReceiptHandle: String, message: String, cause: Throwable)
+  extends RuntimeException(message, cause)


### PR DESCRIPTION
This makes Lambda retries faster. They had become much slower when we increased the SQS message visibility to be three times the length of the Lambda timeout: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/architecture-decision-records/0020-sqs-visibility-timeout.md

This change means that the retry happens immediately, not when the message has expired after a few minutes.

The message visibility reset only happens if an error is encountered when fetching the original filepath from the API, downloading the file or updating the downstream queues. Those types of errors might be caused by temporary network glitches, and can be retried.