### PR TITLE
Remove cognito id.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
@@ -64,9 +64,6 @@ class Lambda {
         .map(record => {
           val s3KeyArr = record.getS3.getObject.getKey.split("/")
           val userId = s3KeyArr.head
-          // This is the same value as the userId as it's the first part of the path. We need both for now so the antivirus doesn't break when deploying.
-          // Once this and the antivirus changes are merged, the cognitoId variable can be deleted and removed from the outgoing json.
-          val cognitoId = s3KeyArr.head
           val fileId = UUID.fromString(s3KeyArr.last)
           val consignmentId = UUID.fromString(s3KeyArr.init.tail(0))
           logger.info(
@@ -83,7 +80,7 @@ class Lambda {
             val s3Response = fileUtils.writeFileFromS3(writePath, fileId, record, s3).map(_ => {
               val output = DownloadOutput(consignmentId, fileId, originalPath).asJson.noSpaces
               fileFormatSendMessage(output)
-              antivirusSendMessage(AntivirusDownloadOutput(consignmentId, fileId, originalPath, cognitoId, userId, dirtyBucketName).asJson.noSpaces)
+              antivirusSendMessage(AntivirusDownloadOutput(consignmentId, fileId, originalPath, userId, dirtyBucketName).asJson.noSpaces)
               checksumSendMessage(output)
               eventWithReceiptHandle.receiptHandle
             })
@@ -127,5 +124,5 @@ class Lambda {
 
 object Lambda {
   case class DownloadOutput(consignmentId: UUID, fileId: UUID, originalPath: String)
-  case class AntivirusDownloadOutput(consignmentId: UUID, fileId: UUID, originalPath: String, cognitoId: String, userId: String, dirtyBucketName: String)
+  case class AntivirusDownloadOutput(consignmentId: UUID, fileId: UUID, originalPath: String, userId: String, dirtyBucketName: String)
 }


### PR DESCRIPTION
The antivirus changes to stop using `cognitoId` and start using `userId`
have been merged so it can be removed from the outgoing json sent to the
antivirus lambda.
