### PR TITLE
Upgrade sbt assembly

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 resolvers += Resolver.jcenterRepo
-addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.21.0")


### PR DESCRIPTION
For some reason, Scala steward is ignoring this.

Also remove the S3 resolver as we've moved everything to maven central
now
