### PR TITLE
Use underscore instead of dash.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/downloadfiles/Lambda.scala
@@ -35,7 +35,7 @@ import scala.util.{Failure, Success, Try}
 class Lambda {
   val config: Config = ConfigFactory.load
   val kmsUtils: KMSUtils = KMSUtils(kms(config.getString("kms.endpoint")), Map("LambdaFunctionName" -> config.getString("function.name")))
-  val clientSecret: String = getClientSecret(config.getString("auth.client.secret-path"), config.getString("ssm.endpoint"))
+  val clientSecret: String = getClientSecret(config.getString("auth.client.secret_path"), config.getString("ssm.endpoint"))
   val lambdaConfig: Map[String, String] = kmsUtils.decryptValuesFromConfig(
     List(
       "sqs.queue.input",

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -28,7 +28,7 @@ auth {
         id = "Y2xpZW50X2lk" # client_id
         secret = "c2VjcmV0" # secret
         secret = "c2VjcmV0" # secret
-        secret-path = "L2Evc2VjcmV0L3BhdGg=" # Base 64 decodes to this value to /a/secret/path
+        secret_path = "L2Evc2VjcmV0L3BhdGg=" # Base 64 decodes to this value to /a/secret/path
     }
 }
 kms {

--- a/src/test/scala/uk/gov/nationalarchives/downloadfiles/FileUtilsTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/downloadfiles/FileUtilsTest.scala
@@ -29,7 +29,7 @@ class FileUtilsTest extends AnyFlatSpec with MockitoSugar with ScalaFutures  {
   val lambdaConfig: Map[String, String] = Map(
     "auth.client.id" -> "client_id",
     "auth.client.secret" -> "secret",
-    "auth.client.secret-path" -> "/a/secret/path",
+    "auth.client.secret_path" -> "/a/secret/path",
     "url.auth" -> "authUrl")
 
   implicit val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()


### PR DESCRIPTION
The application property used secret_path but the code used secret-path
which isn't working so I've changed them all to underscore.
